### PR TITLE
✨ Allow local audio files in background-audio

### DIFF
--- a/extensions/amp-story/1.0/audio.js
+++ b/extensions/amp-story/1.0/audio.js
@@ -33,10 +33,7 @@ export function upgradeBackgroundAudio(element, loop = true) {
     return null;
   }
   const audioEl = element.ownerDocument.createElement('audio');
-  const audioSrc = Services.urlForDoc(element).assertHttpsUrl(
-    element.getAttribute('background-audio'),
-    element
-  );
+  const audioSrc = element.getAttribute('background-audio');
   audioEl.setAttribute('src', audioSrc);
   audioEl.setAttribute('preload', 'auto');
   if (loop) {


### PR DESCRIPTION
Removes https check to allow for local usage of background-audio property in a story or page.